### PR TITLE
feat(i18n): 多言語対応の基盤を追加

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,27 @@
+import {NextResponse} from 'next/server';
+import type {NextRequest} from 'next/server';
+import {locales, defaultLocale} from './src/i18n';
+
+export function middleware(request: NextRequest) {
+  const {pathname} = request.nextUrl;
+
+  // 静的/Api は除外
+  if (pathname.startsWith('/_next') || pathname.startsWith('/api') || pathname.includes('.')) {
+    return;
+  }
+
+  // すでに /ja /en のようにロケールがついていれば何もしない
+  const hasLocale = (locales as readonly string[]).some(
+    (l) => pathname === `/${l}` || pathname.startsWith(`/${l}/`)
+  );
+  if (hasLocale) return;
+
+  // 付いていなければ defaultLocale を付与してリダイレクト
+  const url = request.nextUrl.clone();
+  url.pathname = `/${defaultLocale}${pathname}`;
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: ['/((?!_next|api|.*\\..*).*)']
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/supabase-js": "^2.56.0",
         "ioredis": "^5.7.0",
         "next": "^15.5.0",
+        "next-intl": "^4.3.7",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -810,6 +811,66 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1710,6 +1771,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -3703,6 +3770,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5308,6 +5381,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/ioredis": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
@@ -6559,6 +6644,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.2.tgz",
@@ -6607,6 +6701,33 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.3.7.tgz",
+      "integrity": "sha512-2bVsHSnSj5boJMaUR5SY6bu3khFtNf0he+s1nj23PFGWPCYWHPqa+FOe4YCzkKw1BpB+3UkUn1PNqJCdZNpWwg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.3.7"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -8385,6 +8506,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.3.7.tgz",
+      "integrity": "sha512-IkRFatZEIAm+JfFBAU2Bleb3f2DVt8WldIn5EZVSVu4D5U0QYq2hwB28LHAt15TDhfQw5sdEPsDpvJ2Uj8HjqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@supabase/supabase-js": "^2.56.0",
     "ioredis": "^5.7.0",
     "next": "^15.5.0",
+    "next-intl": "^4.3.7",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,0 +1,53 @@
+import { notFound } from 'next/navigation';
+import I18nProvider from '@/components/I18nProvider';
+import HtmlLangSync from '@/components/HtmlLangSync';
+import { locales, rtlLocales, type Locale } from '@/i18n';
+import '@/styles/tokens.css';
+
+export function generateStaticParams() {
+  return locales.map((l) => ({ locale: l }));
+}
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  return {
+    title: 'OneGlobe',
+    description: 'One world, one conversation.',
+    alternates: {
+      languages: Object.fromEntries(locales.map((l) => [l, `/${l}`]))
+    }
+  };
+}
+
+export default async function LocaleLayout({
+  children,
+  params
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: Locale }>;
+}) {
+  const { locale } = await params;
+  if (!(locales as readonly string[]).includes(locale)) notFound();
+
+  // 直 import で辞書読込（config 不要）
+  const messages = (await import(`@/i18n/${locale}.json`)).default;
+
+  // SSR/CSR の時刻差を防ぐ
+  const now = Date.now();
+  const isRTL = rtlLocales.includes(locale);
+
+  // ★ html/body は描かない（RootLayout が担当）
+  return (
+  <div data-locale={locale} data-dir={isRTL ? 'rtl' : 'ltr'}>
+    <HtmlLangSync lang={locale} dir={isRTL ? 'rtl' : 'ltr'} />
+    <I18nProvider locale={locale} messages={messages} timeZone="Asia/Tokyo" now={now}>
+      {children}
+      </I18nProvider>
+      <div className="text-xs text-gray-500">locale: {locale}</div>
+  </div>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+import {useTranslations} from 'next-intl';
+
+export default function Home() {
+  const t = useTranslations();
+  return (
+    <main className="p-6 space-y-3">
+      <h1 className="text-2xl font-bold">{t('app.name')}</h1>
+      <p>{t('app.tagline')}</p>
+
+      {/* 差が分かる例 */}
+      <div className="mt-4">
+        <p>{t('nav.settings')}</p>
+        <button className="mt-2 px-3 py-1 rounded border">{t('chat.send')}</button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,15 @@
-import './globals.css'
-import '@/app/styles/tokens.css'
-
 export const metadata = {
   title: 'OneGlobe',
-  description: 'One world, one conversation.',
-}
+  description: 'One world, one conversation.'
+};
 
+// Root はドキュメントシェルのみ（<html>/<body>は Root だけで描画）
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja">
-      <body style={{ fontFamily: 'var(--font-sans)' }}>{children}</body>
+    <html lang="ja" dir="ltr" suppressHydrationWarning>
+      <body style={{ fontFamily: 'var(--font-sans)' }}>
+        {children}
+      </body>
     </html>
-  )
+  );
 }

--- a/src/components/HtmlLangSync.tsx
+++ b/src/components/HtmlLangSync.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function HtmlLangSync({
+  lang,
+  dir
+}: {
+  lang: string;
+  dir: 'ltr' | 'rtl';
+}) {
+  useEffect(() => {
+    const el = document.documentElement;
+    if (el.lang !== lang) el.lang = lang;
+    if (el.dir !== dir) el.dir = dir;
+  }, [lang, dir]);
+  return null;
+}

--- a/src/components/I18nProvider.tsx
+++ b/src/components/I18nProvider.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import {NextIntlClientProvider} from 'next-intl';
+
+type Props = {
+  locale: string;
+  messages: Record<string, unknown>;
+  timeZone?: string;
+  /** サーバから渡す固定時刻（number | string | Date どれでもOK） */
+  now: number | string | Date;
+  children: React.ReactNode;
+};
+
+export default function I18nProvider({
+  locale,
+  messages,
+  timeZone = 'Asia/Tokyo',
+  now,
+  children
+}: Props) {
+  // 受けとった now を Date に正規化（クライアントで new Date() は作らない）
+  const fixedNow = typeof now === 'number' || typeof now === 'string' ? new Date(now) : now;
+
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone={timeZone} now={fixedNow}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,32 @@
+'use client';
+import {usePathname, useRouter} from 'next/navigation';
+import {locales, localeLabels, type Locale} from '@/i18n';
+
+export function LanguageSwitcher({current}: {current: Locale}) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  function switchTo(target: Locale) {
+    if (!pathname) return;
+    const parts = pathname.split('/');
+    parts[1] = target; // 先頭のロケールセグメントを置換
+    router.push(parts.join('/'));
+  }
+
+  return (
+    <div className="inline-flex gap-2">
+      {locales.map((l) => (
+        <button
+          key={l}
+          onClick={() => switchTo(l)}
+          aria-current={l === current ? 'page' : undefined}
+          className={`px-3 py-1 rounded-md border ${
+            l === current ? 'bg-[var(--color-surface)] font-semibold' : ''
+          }`}
+        >
+          {localeLabels[l]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,13 @@
+{
+  "app": {
+    "name": "OneGlobe",
+    "tagline": "One world, one conversation."
+  },
+  "nav": { "rooms": "Rooms", "settings": "Settings" },
+  "auth": { "login": "Log in", "logout": "Log out" },
+  "chat": { "send": "Send", "typing": "{name} is typing..." },
+  "settings": {
+    "language": "Language",
+    "languageNote": "No flags; show language name + ISO code"
+  }
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,10 @@
+export const locales = ['en', 'ja'] as const;
+export type Locale = typeof locales[number];
+
+export const defaultLocale: Locale = 'ja';
+export const rtlLocales: Locale[] = [];
+
+export const localeLabels = {
+  en: 'English (en)',
+  ja: '日本語 (ja)'
+} satisfies Record<Locale, string>;

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -1,0 +1,13 @@
+{
+  "app": {
+    "name": "OneGlobe",
+    "tagline": "ひとつの世界、ひとつの会話。"
+  },
+  "nav": { "rooms": "ルーム", "settings": "設定" },
+  "auth": { "login": "ログイン", "logout": "ログアウト" },
+  "chat": { "send": "送信", "typing": "{name} さんが入力中..." },
+  "settings": {
+    "language": "言語",
+    "languageNote": "国旗は使わず言語名＋コードで表示"
+  }
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,22 @@
+:root {
+  /* Colors */
+  --color-brand-primary: #2563eb;
+  --color-brand-secondary: #14b8a6;
+  --color-accent: #22c55e;
+  --color-warning: #f59e0b;
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #334155;
+  --color-bg: #ffffff;
+  --color-surface: #f6f8fb;
+  --color-border: #e2e8f0;
+
+  /* Radius */
+  --radius-md: 12px;
+  --radius-lg: 16px;
+
+  /* Shadow */
+  --shadow-sm: 0 2px 10px rgba(15, 23, 42, 0.06);
+
+  /* Typography */
+  --font-sans: 'Inter', 'Noto Sans JP', sans-serif;
+}


### PR DESCRIPTION
## 📝 概要
i18n（多言語対応）の基盤を導入しました。  
/ja, /en で翻訳が切り替わることを確認済みです。

## 🔄 変更点
- `next-intl` を導入
- 辞書ファイル `src/i18n/{en.json, ja.json}` を追加
- `src/app/[locale]/layout.tsx` を新規作成し、`I18nProvider` を提供
- `middleware.ts` を追加し、ルートアクセス時にデフォルトロケールへリダイレクト
- Root Layout を修正し `<html>/<body>` の描画を統一
- `tokens.css` / `components/` ディレクトリを追加
- `package.json` / `package-lock.json` を更新

## ✅ 動作確認
- `npm run dev` でサーバー起動
- `http://localhost:3000/ja` にアクセス → 日本語辞書が反映される
- `http://localhost:3000/en` にアクセス → 英語辞書が反映される
- Hydration mismatch 警告なし

## 🎯 CloseするIssue
- close #XX （対応するIssue番号を記入してください）

## 📸 スクリーンショット（任意）
- `/ja` と `/en` 表示
<img width="1014" height="677" alt="スクリーンショット 2025-09-12 7 08 36" src="https://github.com/user-attachments/assets/821e2873-80fe-4153-8f65-8ec2191b3b3a" />
